### PR TITLE
Update TM16xx.cpp

### DIFF
--- a/src/TM16xx.cpp
+++ b/src/TM16xx.cpp
@@ -61,7 +61,7 @@ TM16xx::TM16xx(byte dataPin, byte clockPin, byte strobePin, byte maxDisplays, by
 
 void TM16xx::setupDisplay(boolean active, byte intensity)
 {
-  sendCommand(TM16XX_CMD_DISPLAY | (active ? 8 : 0) | min(7, intensity));
+  sendCommand(TM16XX_CMD_DISPLAY | (active ? 8 : 0) | (7 & intensity));
 }
 
 void TM16xx::clearDisplay()


### PR DESCRIPTION
ESP compiler (and possibly others) implements min() and max() as functions, requiring identical data type of operands. This makes it difficult to use for the purpose of masking the brightness bits. I propose a simpler method, just logical 'and' with a bit mask.